### PR TITLE
charts.css.py 0.2.0

### DIFF
--- a/charts/__init__.py
+++ b/charts/__init__.py
@@ -1,0 +1,2 @@
+# Add this file to make it NOT a namespace package.
+# Note: Brython does not seem to support loading a namespace package.

--- a/charts/css.py
+++ b/charts/css.py
@@ -1,7 +1,7 @@
 ## Avoid `typing` due to its significant overhead in some Python implementation
 #from typing import Optional, Callable, List
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 
 class Legend:  # https://chartscss.org/components/legend/
@@ -256,8 +256,3 @@ def wrapper(*charts, wrapper_id=None, layout=None, arrangement=None):
     )
 
 STYLESHEET = '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/charts.css/dist/charts.min.css">'
-
-
-if __name__ == "__main__":
-    pass
-

--- a/charts/css.py
+++ b/charts/css.py
@@ -1,12 +1,12 @@
-from typing import List, Optional, Tuple, Callable, Mapping, Union
-import string
+## Avoid `typing` due to its significant overhead in some Python implementation
+#from typing import Optional, Callable, List
 
 __version__ = "0.1.0"
 
 
 class Legend:  # https://chartscss.org/components/legend/
     _shape = ""
-    def __init__(self, legends: List[str], inline=None):
+    def __init__(self, legends: list, inline=None):
         self._legends = legends
         self._inline = inline  # True if inline is None else inline
     def __str__(self):
@@ -43,10 +43,11 @@ def _chart(
     *,
     headers_in_first_row=False,
     headers_in_first_column=False,
-    legend: Optional[Legend] = None,  # https://chartscss.org/components/legend/
+    legend=None,  # https://chartscss.org/components/legend/
     legend_inline=False,
 
-    _series_upper_bound: Optional[Callable[[], int]] = None,  # https://chartscss.org/components/stacked/#simple-vs-percentage
+    _series_upper_bound=None,  # In the shape of lambda a_list: a_value
+        # https://chartscss.org/components/stacked/#simple-vs-percentage
     value_displayer=lambda value: value,
     stacked=False,  # Only applicable to bar and column charts. https://chartscss.org/components/stacked/
 
@@ -61,11 +62,11 @@ def _chart(
 
     #show_primary_axis=False,
     #show_data_axis=False,
-    show_secondary_axes: Optional[int] = None,
+    show_secondary_axes=None,
 
     # https://chartscss.org/components/spacing/
-    data_spacing: Optional[int] = None,
-    datasets_spacing: Optional[int] = None,
+    data_spacing=None,
+    datasets_spacing=None,
 
     # More customizing can be done by regular css: https://chartscss.org/components/wrapper/#customizing-the-chart
     # and https://chartscss.org/customization/
@@ -241,6 +242,7 @@ ul.charts-css.legend {
      # https://developer.mozilla.org/en-US/docs/Web/CSS/writing-mode#examples
 
 def wrapper(*charts, wrapper_id=None, layout=None, arrangement=None):
+    import string
     wrapper_id = wrapper_id or "my_chart"
     return """<style>{layout}{arrangement}</style>
 <div id="{wrapper_id}">

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,8 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: Brython
 
 # NOTE: Settings of this section below this line should not need to be changed
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,9 +35,7 @@ install_requires =
     # See also https://setuptools.readthedocs.io/en/latest/userguide/quickstart.html#dependency-management
 
 # NOTE: Settings of this section below this line should not need to be changed
-#packages = find:
-# This project uses namespace. See https://setuptools.readthedocs.io/en/latest/userguide/package_discovery.html#using-find-namespace-or-find-namespace-packages
-packages = find_namespace:
+packages = find:
 include_package_data = True
 
 [options.extras_require]


### PR DESCRIPTION
* Remove `typing` annotation to reduce overhead on some certain platforms
* Also move away from using namespace package