### PR TITLE
Release 0.3.0

### DIFF
--- a/.github/workflows/publish-to-github-pages.yml
+++ b/.github/workflows/publish-to-github-pages.yml
@@ -1,0 +1,25 @@
+name: Publish to Github Pages (you still need to enable Github Pages for your project)
+
+on:
+  push:
+    branches: [ dev ]
+  pull_request:
+    branches: [ dev ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Publish to GitHub Pages
+        uses: rayluo/github-pages-overwriter@v1.2
+        with:
+          source-directory: website
+

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Then you write such a string into your HTML page, together with
 `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/charts.css/dist/charts.min.css">`,
 the visual representation will be rendered by browser.
 
-For example, the following code snippet can convert a 2-dimension list into bar chart:
+For example, the following code snippet can convert a 2-dimension list into column chart:
 
 ```python
-    from charts.css import bar, STYLESHEET
-    chart = bar(
-       [
+    from charts.css import column, STYLESHEET
+    chart = column(
+        [
             ["Continent", "1st year", "2nd year", "3rd year", "4th year", "5th year"],
             ["Asia", 20.0, 30.0, 40.0, 50.0, 75.0],
             ["Euro", 40.0, 60.0, 75.0, 90.0, 100.0],
@@ -34,6 +34,10 @@ For example, the following code snippet can convert a 2-dimension list into bar 
         headers_in_first_row=True,
         headers_in_first_column=True,
         )
+    # Now, variable chart contains html snippet of "<table>...</table>", and
+    # STYLESHEET is just a constant string of "<link href='https://.../charts.css'>".
+    # You can somehow insert them into the proper places of your full html page.
+    # Here in this sample, we take a shortcut by simply concatenating them.
     open("output.html", "w").write(STYLESHEET + chart)
 ```
 

--- a/charts/css.py
+++ b/charts/css.py
@@ -123,7 +123,10 @@ def _chart(
     padding = 0.2 if _type == "line" else 0  # TODO: How to choose a value fitting the current datasets?
 
     def numeric_values_in_a_row(row):
-        values = [cell["value"] for cell in row[1 if headers_in_first_column else 0:]]
+        _data_starts_at_row = (
+            # Brython 3.7 and 3.8 do not support merging this ternary into next line
+            1 if headers_in_first_column else 0)
+        values = [cell["value"] for cell in row[_data_starts_at_row:]]
         if not values:
             raise ValueError("Inputed rows should contain at least one numeric column")
         for v in values:

--- a/charts/css.py
+++ b/charts/css.py
@@ -210,7 +210,9 @@ def column(rows, *, stacked=False, percentage=False, **kwargs) -> str:
 def area(rows, **kwargs) -> str:
     return _chart(rows, "area", **kwargs)
 
-def line(rows, **kwargs) -> str:
+def line(rows, data_spacing=None, datasets_spacing=None, **kwargs) -> str:
+    if data_spacing or datasets_spacing:
+        raise ValueError("data_spacing or datasets_spacing would break line into segments")
     return _chart(rows, "line", **kwargs)
 
 

--- a/charts/css.py
+++ b/charts/css.py
@@ -1,7 +1,7 @@
 ## Avoid `typing` due to its significant overhead in some Python implementation
 #from typing import Optional, Callable, List
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 
 class Legend:  # https://chartscss.org/components/legend/

--- a/scripts/csv2chart.py
+++ b/scripts/csv2chart.py
@@ -48,16 +48,17 @@ def main():
         '--legend', nargs='?', choices=legends.keys(), help="Legend type")
     parser.add_argument('--legend_inline', action="store_true")
     parser.add_argument('--stacked', action="store_true")
+    parser.add_argument('--hide_data', action="store_true")
     parser.add_argument('--heading')
     parser.add_argument(
         '--secondary_axes',
         nargs='?', type=int, default=5, choices=SHOW_SECONDARY_AXES)
     parser.add_argument(
         '--data_spacing',
-        nargs='?', type=int, default=20, choices=DATA_SPACING)
+        nargs='?', type=int, default=0, choices=DATA_SPACING)
     parser.add_argument(
         '--datasets_spacing',
-        nargs='?', type=int, default=5, choices=DATASETS_SPACING)
+        nargs='?', type=int, default=0, choices=DATASETS_SPACING)
     parser.add_argument('--value_displayer', default="{}",
         help="A string template containing a pair of curly brackets, e.g. '${}K'")
 
@@ -74,6 +75,7 @@ def main():
         data_spacing=args.data_spacing,
         datasets_spacing=args.datasets_spacing,
         value_displayer=args.value_displayer.format,
+        hide_data=args.hide_data,
         )))
 
 if __name__ == "__main__":

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,8 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
-    Programming Language :: Python :: Implementation :: Brython
+    ## There is no Brython classifier, yet?
+    #Programming Language :: Python :: Implementation :: Brython
 
 # NOTE: Settings of this section below this line should not need to be changed
 

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,334 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Charts.css.py Online Document</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/charts.css/dist/charts.min.css">
+    <style>
+    .charts-css {  /* You have to use this class name */
+      height: 400px;  /* Most charts need some height to operate */
+      width: 80%;  /* Optional */
+      margin: 0 auto;  /* Optional */
+    }
+    .charts-css.legend.legend-inline {  /* You have to use this class name */
+      height: 3em;  /* Optional */
+    }
+    /* TBD
+    .line th {
+      align-items: end;
+    }
+    */
+    pre {
+      margin-left: 2em;
+      background-color: #eee;
+    }
+    code {
+      background-color: #eee;
+    }
+    </style>
+  </head>
+  <body id="body" onload="brython()" class="container">
+
+<h1>Charts.css.py Online Document</h1>
+
+<h2>Introduction</h2>
+<p>
+As implied by its name, <code>charts.css.py</code> brings <code>charts.css</code> to Python.
+</p>
+<p>
+<a href="https://chartscss.org/" target=_blank>Charts.css</a> is a pure-CSS data visualization framework,
+which allows your HTML table to be rendered as a chart inside browser.
+It offers <a href="https://chartscss.org/docs/#alternatives" target=_blank>advantages over traditional JS-heavy chart libraries</a>.
+</p>
+<p>
+<code>charts.css.py</code> provides a pythonic API to convert your 2-dimension lists into html table,
+so that you can largely avoid working directly at HTML and CSS level.
+The output of <code>charts.css.py</code> is not an image,
+but an HTML snippet for you to insert into your html page,
+which will be rendered by <code>charts.css</code>.
+</p>
+
+<h2>Bar chart with single dataset</h2>
+Let's start this document with a simple sample.
+Our first sample shows the basic usage pattern, visualizing single dataset with default effect.
+You still need to organize your single dataset as a 2-dimension list.
+<pre id="bar1r_source"></pre>
+<script type="text/python" id="bar1r_sample">
+from charts.css import bar
+chart = bar(
+    [
+        [1],
+        [2],
+        [4],
+        [6],
+        [8],
+        [10],
+    ],
+    )
+## Note: The following one-row approach happens to generate a chart looks the same.
+#        However, we would recommend the one-column approach,
+#        because it aligns better with the rest of our other samples.
+# chart = bar([[1, 2, 4, 6, 8, 10]])
+#
+# Now, variable chart contains html snippet of "< table >...< /table >",
+# which you can somehow insert into the proper place of your html page.
+# Consider the following 2 lines as pseudo-code.
+from browser import document
+document["bar1r_output"].html = chart
+</script>
+<div id="bar1r_output">Loading......</div>
+<script>document.getElementById("bar1r_source").innerHTML = document.getElementById("bar1r_sample").innerHTML</script>
+
+<h2>Installation</h2>
+If you are working on a normal Python project, you can install by <code>pip</code>:
+<pre>pip install charts.css.py</pre>
+If your project is powered by Brython, you can choose to use our JS package.
+(The version number below might not be up-to-date. Please get latest version from
+<a href="https://github.com/rayluo/charts.css.py/releases" target=_blank>Release page</a>.)
+<pre>
+&lt;script src="https://github.com/rayluo/charts.css.py/releases/download/0.2.0/charts.css.py-brython.js"&gt;&lt;/script&gt;
+</pre>
+
+<h2>Configuration</h2>
+First of all, insert this snippet into your html page,
+typically inside the &lt;head&gt;...&lt;/head&gt; tag:
+<pre>
+&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/charts.css/dist/charts.min.css"&gt;
+&lt;style&gt;
+.charts-css {  /* You have to use this class name */
+  height: 400px;  /* Most charts need some height to operate */
+  width: 80%;  /* Optional */
+  margin: 0 auto;  /* Optional */
+}
+.charts-css.legend.legend-inline {  /* You have to use this class name */
+  height: 3em;  /* Optional */
+}
+&lt;/style&gt;
+</pre>
+
+<h2>Data Format</h2>
+All chart functions in <code>charts.css.py</code> have a unified data format as a 2-dimension list,
+optionally with headers in the first column and/or first row. They look like this:
+<pre>
+data = [
+    ["Continent", "1st year", "2nd year", "3rd year", "4th year", "5th year"],
+    ["Asia", 20.0, 30.0, 40.0, 50.0, 75.0],
+    ["Euro", 40.0, 60.0, 75.0, 90.0, 100.0],
+    ]
+</pre>
+Even when you are working with one-dimension data,
+you would still need to format them as 2-dimension list, which contains one column:
+<pre>
+data = [
+    [20.0],
+    [40.0],
+    ]
+</pre>
+Some charts can also work with one row:
+<pre>
+data = [
+    [20.0, 30.0, 40.0, 50.0, 75.0],
+    ]
+</pre>
+
+<h2>Bar chart with single dataset and headers</h2>
+<p>
+Same raw data as the previous sample, now with headers.
+The headers in first column are visible in chart, but headers in first row are not.
+</p>
+<p>
+This sample also demonstrates lots of optional effects.
+Unless stated otherwise, all the chart functions
+(<code>bar()</code>, <code>column()</code>, <code>line()</code> and <code>area()</code>)
+support same parameters.
+</p>
+<pre id="bar1c_source"></pre>
+<script type="text/python" id="bar1c_sample">
+from charts.css import bar
+chart = bar(
+    [
+        ["Month", "Amount"],  # Header row is actually not rendered in chart
+        ["Jan", 1],
+        ["Feb", 2],
+        ["Mar", 4],
+        ["Apr", 6],
+        ["May", 8],
+        ["Jun", 10],
+    ],
+    headers_in_first_row=True,
+    headers_in_first_column=True,
+    hide_data=True,
+    show_data_on_hover=True,
+    heading="My Bank Account Balance",
+    value_displayer=lambda value: "${}K".format(value),
+    show_secondary_axes=10,
+    data_spacing=15,
+    )
+# Now, variable chart contains html snippet of "< table >...< /table >",
+# which you can somehow insert into the proper place of your html page.
+# Consider the following 2 lines as pseudo-code.
+from browser import document
+document["bar1c_output"].html = chart
+</script>
+<div id="bar1c_output">Loading......</div>
+<script>document.getElementById("bar1c_source").innerHTML = document.getElementById("bar1c_sample").innerHTML</script>
+
+<h2>Column chart with multiple datasets</h2>
+Multiple datasets mean there are multiple columns from your 2-dimension list input.
+<pre id="column_source"></pre>
+<script type="text/python" id="column_sample">
+from charts.css import (
+    column,
+    LegendCircle, LegendEllipse, LegendSquare, LegendRectangle, LegendRhombus, LegendLine)
+chart = column(
+    [
+        ["Continent", "1st year", "2nd year", "3rd year", "4th year", "5th year"],
+        ["Asia", 20.0, 30.0, 40.0, 50.0, 75.0],
+        ["Euro", 40.0, 60.0, 75.0, 90.0, 100.0],
+        ["America", 50, 50, 30, 20, 25],
+        ["Africa", 20, 20, 20, 20, 20],
+    ],
+    headers_in_first_row=True,
+    headers_in_first_column=True,
+    data_spacing=20,
+    datasets_spacing=4,
+    heading="Charts.css.py global sales volume",
+    legend=LegendRhombus,  # Legend is meaningful when you have multiple datasets
+    legend_inline=True,  # Optional
+    value_displayer="${}K".format,  # More convenient than a lambda
+    )
+# Now, variable chart contains html snippet of "< table >...< /table >",
+# which you can somehow insert into the proper place of your html page.
+# Consider the following 2 lines as pseudo-code.
+from browser import document
+document["column_output"].html = chart
+</script>
+<div id="column_output">Loading......</div>
+<script>document.getElementById("column_source").innerHTML = document.getElementById("column_sample").innerHTML</script>
+
+<h2>Column chart, stacked by face value</h2>
+<code>bar()</code> and <code>column()</code> support a boolean parameter <code>stacked</code>.
+Simply enable that, you will get a stacked bar chart (or column chart).
+<pre id="column_stacked_source"></pre>
+<script type="text/python" id="column_stacked_sample">
+from charts.css import (
+    column,
+    LegendCircle, LegendEllipse, LegendSquare,
+    LegendRectangle, LegendRhombus, LegendLine)
+chart = column(
+    [
+        ["Continent", "1st year", "2nd year", "3rd year", "4th year", "5th year"],
+        ["Asia", 20.0, 30.0, 40.0, 50.0, 75.0],
+        ["Euro", 40.0, 60.0, 75.0, 90.0, 100.0],
+        ["America", 50, 50, 30, 20, 25],
+        ["Africa", 20, 20, 20, 20, 20],
+    ],
+    stacked=True,  # <-- This generates the stacked chart
+    headers_in_first_row=True,
+    headers_in_first_column=True,
+    data_spacing=20,
+    heading="Charts.css.py global sales volume",
+    legend=LegendRhombus,  # Legend works best when you have multiple datasets
+    legend_inline=True,  # Optional
+    value_displayer="${}K".format,  # More convenient than a lambda
+    )
+# Now, variable chart contains html snippet of "< table >...< /table >",
+# which you can somehow insert into the proper place of your html page.
+# Consider the following 2 lines as pseudo-code.
+from browser import document
+document["column_stacked_output"].html = chart
+</script>
+<div id="column_stacked_output">Loading......</div>
+<script>document.getElementById("column_stacked_source").innerHTML = document.getElementById("column_stacked_sample").innerHTML</script>
+
+<h2>Column chart, stacked by percentage</h2>
+A <code>percentage=True</code> can switch stacked column or bar chart to percentage view.
+<pre id="column_stacked_percentage_source"></pre>
+<script type="text/python" id="column_stacked_percentage_sample">
+from charts.css import (
+    column,
+    LegendCircle, LegendEllipse, LegendSquare,
+    LegendRectangle, LegendRhombus, LegendLine)
+chart = column(
+    [
+        ["Continent", "1st year", "2nd year", "3rd year", "4th year", "5th year"],
+        ["Asia", 20.0, 30.0, 40.0, 50.0, 75.0],
+        ["Euro", 40.0, 60.0, 75.0, 90.0, 100.0],
+        ["America", 50, 50, 30, 20, 25],
+        ["Africa", 20, 20, 20, 20, 20],
+    ],
+    stacked=True,  # <-- This generates the stacked chart
+    percentage=True,  # <-- This stacks each cell by its percentage in its dataset
+    headers_in_first_row=True,
+    headers_in_first_column=True,
+    data_spacing=20,
+    heading="Charts.css.py global sales volume",
+    legend=LegendRhombus,  # Legend works best when you have multiple datasets
+    legend_inline=True,  # Optional
+    value_displayer="${}K".format,  # More convenient than a lambda
+    )
+# Now, variable chart contains html snippet of "< table >...< /table >",
+# which you can somehow insert into the proper place of your html page.
+# Consider the following 2 lines as pseudo-code.
+from browser import document
+document["column_stacked_percentage_output"].html = chart
+</script>
+<div id="column_stacked_percentage_output">Loading......</div>
+<script>document.getElementById("column_stacked_percentage_source").innerHTML = document.getElementById("column_stacked_percentage_sample").innerHTML</script>
+
+<h2>Line chart</h2>
+Line charts display raw data connected with a straight line.
+The input is still a 2-dimension list.
+Note that each vertical "column" - rather than the horizontal "row" - is rendered as a horizontal line.
+<pre id="line_source"></pre>
+<script type="text/python" id="line_sample">
+from charts.css import line
+chart = line(
+    [
+        ["Date", "AAPL", "MSFT", "ORCL", "QCOM", "CSCO"],
+        ["Jan 1", 150.0, 140.0, 200.0, 50.0, 175.0],
+        ["Feb 1", 110.0, 260.0, 75.0, 90.0, 100.0],
+        ["Mar 1", 125.43, 245.17, 79.03, 151.46, 52.43],
+    ],
+    headers_in_first_row=True,
+    headers_in_first_column=True,
+    heading="Investment Portfolio",
+    )
+# Now, variable chart contains html snippet of "< table >...< /table >",
+# which you can somehow insert into the proper place of your html page.
+from browser import document
+document["line_output"].html = chart
+</script>
+<div id="line_output">Loading......</div>
+<script>document.getElementById("line_source").innerHTML = document.getElementById("line_sample").innerHTML</script>
+
+<h2>Area</h2>
+Area charts work similar to line charts, plus they display raw data with colors between axis and line.
+<pre id="area_source"></pre>
+<script type="text/python" id="area_sample">
+from charts.css import area
+chart = area(
+    [
+        ["Date", "AAPL", "MSFT", "ORCL"],
+        ["Jan 1", 150.0, 140.0, 200.0],
+        ["Feb 1", 110.0, 260.0, 75.0],
+        ["Mar 1", 125.43, 245.17, 79.03],
+    ],
+    headers_in_first_row=True,
+    headers_in_first_column=True,
+    heading="Investment Portfolio",
+    )
+# Now, variable chart contains html snippet of "< table >...< /table >",
+# which you can somehow insert into the proper place of your html page.
+from browser import document
+document["area_output"].html = chart
+</script>
+<div id="area_output">Loading......</div>
+<script>document.getElementById("area_source").innerHTML = document.getElementById("area_sample").innerHTML</script>
+
+    <script src="https://cdn.jsdelivr.net/npm/brython@3/brython.min.js"></script>
+    <script src="https://github.com/rayluo/charts.css.py/releases/download/0.2.0/charts.css.py-brython.js"></script>
+  </body>
+</html>
+


### PR DESCRIPTION
* Line chart should not accept non-zero `data_spacing` or `datasets_spacing`. Now it would rightfully reject such an input.
* Provide an [online document/sample](https://rayluo.github.io/charts.css.py/)
* Backport to Brython 3.7 and 3.8. The recommended Brython version is still its latest version, currently 3.9.